### PR TITLE
extract full exif and xml metadata from jxl images with metadata compressed

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,6 +10,25 @@ RUN apt-get update && \
         autoconf \
         build-essential \
         jq \
+        perl \
+        libnet-ssleay-perl \
+        libio-socket-ssl-perl \
+        libcapture-tiny-perl \
+        libfile-which-perl \
+        libfile-chdir-perl \
+        libpkgconfig-perl \
+        libffi-checklib-perl \
+        libtest-warnings-perl \
+        libtest-fatal-perl \
+        libtest-needs-perl \
+        libtest2-suite-perl \
+        libsort-versions-perl \
+        libpath-tiny-perl \
+        libtry-tiny-perl \
+        libterm-table-perl \
+        libany-uri-escape-perl \
+        libmojolicious-perl \
+        libfile-slurper-perl \
         libexif-dev \
         libexpat1-dev \
         libglib2.0-dev \
@@ -26,12 +45,14 @@ RUN apt-get update && \
         ninja-build \
         pkg-config \
         wget \
-        zlib1g
+        zlib1g \
+        cpanminus
 
 COPY bin/* .
 RUN ./build-libraw.sh
 RUN ./build-imagemagick.sh
 RUN ./build-libvips.sh
+RUN ./build-perllib-compress-brotli.sh
 
 RUN sed -i -e's/ main/ main contrib non-free non-free-firmware/g' /etc/apt/sources.list.d/debian.sources
 COPY bin/install-ffmpeg.sh bin/build-lock.json ./

--- a/server/bin/build-perllib-compress-brotli.sh
+++ b/server/bin/build-perllib-compress-brotli.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+mkdir -p perllib-compress-brotli
+cd perllib-compress-brotli
+cpanm IO::Compress::Brotli
+cd .. && rm -rf perllib-compress-brotli
+rm -rf /usr/local/lib/*-linux-gnu/perl/*/auto/Alien
+rm -rf /usr/local/lib/*-linux-gnu/perl/*/auto/share/
+rm -rf /usr/local/lib/*-linux-gnu/perl/*/Alien/
+ldconfig /usr/local/lib


### PR DESCRIPTION
Add support to extract full EXIF and XML metadata from JPEG XL(JXL) files. For a detailed description of the current issue please see [issue](https://github.com/immich-app/immich/issues/5161).

Currently, those that have all or the majority of the images in JPEG XL format will not be able to see/edit any EXIF/XML metadata (GPS data, original datetimes), searching images by metadata and geo tagging information.