### PR TITLE
fix geodata files permissions

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -58,12 +58,13 @@ RUN sed -i -e's/ main/ main contrib non-free non-free-firmware/g' /etc/apt/sourc
 COPY bin/install-ffmpeg.sh bin/build-lock.json ./
 RUN ./install-ffmpeg.sh
 
-ADD https://download.geonames.org/export/dump/cities500.zip /usr/src/resources/cities500.zip
-ADD https://download.geonames.org/export/dump/admin1CodesASCII.txt /usr/src/resources/admin1CodesASCII.txt
-ADD https://download.geonames.org/export/dump/admin2Codes.txt /usr/src/resources/admin2Codes.txt
-
-RUN unzip /usr/src/resources/cities500.zip -d /usr/src/resources/ && \
-    rm /usr/src/resources/cities500.zip && date --iso-8601=seconds | tr -d "\n" > /usr/src/resources/geodata-date.txt
+RUN mkdir -p /usr/src/resources && \
+    wget -qO /usr/src/resources/cities500.zip https://download.geonames.org/export/dump/cities500.zip && \
+    wget -qO /usr/src/resources/admin1CodesASCII.txt https://download.geonames.org/export/dump/admin1CodesASCII.txt && \
+    wget -qO /usr/src/resources/admin2Codes.txt https://download.geonames.org/export/dump/admin2Codes.txt && \
+    unzip /usr/src/resources/cities500.zip -d /usr/src/resources/ && \
+    rm /usr/src/resources/cities500.zip && \
+    date --iso-8601=seconds | tr -d "\n" > /usr/src/resources/geodata-date.txt
 
 FROM node:20.10-bookworm-slim as prod
 WORKDIR /usr/src/app


### PR DESCRIPTION
Fixes immich-app/immich#5404

Please check the issue above for more details.

How to test:

1) Build dev and prod images from scratch:

```
$ docker build --no-cache --target dev -t docker.svc.local/private/base-server-dev:20231130 .
$ docker build --target prod -t docker.svc.local/private/base-server-prod:20231130 .
```

2)  Run the prod base server image:
```
$ docker run -it -d --name immich-base-server docker.svc.local/private/base-server-prod:20231130
```

3) Log into immich-base-server:
```
$ docker exec -it immich-base-server bash
```

4) Check permissions for files in `/usr/src/resources`. It should show `rw-` for owner, `r--` for group, `r--` for others.
```
$ ls -lah /usr/src/resources
total 34M
drwxr-xr-x. 1 root root  128 Nov 30 11:08 .
drwxr-xr-x. 1 root root   18 Nov 30 11:08 ..
-rw-r--r--. 1 root root 136K Nov 30 02:58 admin1CodesASCII.txt
-rw-r--r--. 1 root root 2.2M Nov 30 02:58 admin2Codes.txt
-rw-r--r--. 1 root root  32M Nov 30 03:51 cities500.txt
-rw-r--r--. 1 root root   25 Nov 30 11:07 geodata-date.txt
```

