### PR TITLE
fix(deps): use fixed libvips

### DIFF
--- a/server/bin/build-libraw.sh
+++ b/server/bin/build-libraw.sh
@@ -2,18 +2,12 @@
 
 set -e
 
-LOCK=$(jq -c '.packages[] | select(.name == "libraw")' build-lock.json)
-LIBRAW_VERSION=${LIBRAW_VERSION:=$(echo $LOCK | jq -r '.version')}
-LIBRAW_SHA256=${LIBRAW_SHA256:=$(echo $LOCK | jq -r '.sha256')}
+: "${LIBRAW_REVISION:=$(jq -cr '.sources[] | select(.name == "libraw").revision' build-lock.json)}"
 
-echo "$LIBRAW_SHA256  $LIBRAW_VERSION.tar.gz" > libraw.sha256
-mkdir -p libraw
-wget -nv https://github.com/libraw/libraw/archive/${LIBRAW_VERSION}.tar.gz
-sha256sum -c libraw.sha256
-tar -xvf ${LIBRAW_VERSION}.tar.gz -C libraw --strip-components=1
-rm ${LIBRAW_VERSION}.tar.gz
-rm libraw.sha256
+git clone https://github.com/libraw/libraw.git
 cd libraw
+git reset --hard $LIBVIPS_REVISION
+
 autoreconf --install
 ./configure
 make -j$(nproc)

--- a/server/bin/build-libvips.sh
+++ b/server/bin/build-libvips.sh
@@ -2,21 +2,14 @@
 
 set -e
 
-LOCK=$(jq -c '.packages[] | select(.name == "libvips")' build-lock.json)
-LIBVIPS_VERSION=${LIBVIPS_VERSION:=$(echo $LOCK | jq -r '.version')}
-LIBVIPS_SHA256=${LIBVIPS_SHA256:=$(echo $LOCK | jq -r '.sha256')}
+: "${LIBVIPS_REVISION:=$(jq -cr '.sources[] | select(.name == "libvips").revision' build-lock.json)}"
 
-echo "$LIBVIPS_SHA256  vips-$LIBVIPS_VERSION.tar.xz" > libvips.sha256
-mkdir -p libvips
-wget -nv https://github.com/libvips/libvips/releases/download/v${LIBVIPS_VERSION}/vips-${LIBVIPS_VERSION}.tar.xz
-sha256sum -c libvips.sha256
-tar -xvf vips-${LIBVIPS_VERSION}.tar.xz -C libvips --strip-components=1
-rm vips-${LIBVIPS_VERSION}.tar.xz
-rm libvips.sha256
+git clone https://github.com/libvips/libvips.git
 cd libvips
+git reset --hard $LIBVIPS_REVISION
+
 meson setup build --buildtype=release --libdir=lib -Dintrospection=disabled -Dtiff=disabled
 cd build
-# ninja test  # tests set concurrency too high for arm/v7
 ninja install
 cd .. && rm -rf libvips
 ldconfig /usr/local/lib

--- a/server/bin/build-lock.json
+++ b/server/bin/build-lock.json
@@ -1,20 +1,22 @@
 {
-  "packages": [
+  "sources": [
     {
       "name": "imagemagick",
       "version": "7.1.1-13",
-      "sha256": "8e3ce1aaad19da9f2ca444072bcc631d193a219e3ee11c13ad6d3c895044142c"
+      "revision": "d5974ce50c84bee43731270a899d7a4a9500cc17"
     },
     {
       "name": "libraw",
       "version": "0.21.1",
-      "sha256": "b63d7ffa43463f74afcc02f9083048c231349b41cc9255dec0840cf8a67b52e0"
+      "revision": "cccb97647fcee56801fa68231fa8a38aa8b52ef7"
     },
     {
       "name": "libvips",
-      "version": "8.15.0",
-      "sha256": "d33f81c6ab4bd1faeedc36dc32f880b19e9d5ff69b502e59d175332dfb8f63f1"
-    },
+      "version": "8.15",
+      "revision": "0144d503a4e90ee56830dda9ebc39b2f25ae8b1f"
+    }
+  ],
+  "packages": [
     {
       "name": "ffmpeg",
       "version": "6.0-4",


### PR DESCRIPTION
## Description

This PR targets the current latest commit in the libvips 8.15 branch, which includes a fix for ARW and NEF images (and other RAW formats that are similar to TIFF). As part of this, it changes source code downloading to use git clone with a set revision, meaning there is no longer a need to extract and checksum a tar file. 

The `revision` field in the lock file is the SHA1 hash of a commit, which should generally be the commit that the version tag points to. This value can easily be copied through GH, meaning less friction when updating these dependencies.

## How Has This Been Tested?

I built the dev and prod base images locally and built the server with these images. sharp was able to process a sample ARW image.