### PR TITLE
chore: update cron schedule

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,7 +3,7 @@ name: Git tag
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 11 * * 4"
+    - cron: "0 11 * * 2"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Update the cron schedule to build this image on _Tuesday_, instead of _Thursday_. For a few reasons:
- The main repo does dependency updates on Tuesday
- Releases tend to be during the end of the week

This hopefully makes it easier avoids the situation where a bump is merged right before a release, while making it easy to review with the rest of the dependency PRs