### PR TITLE
chore(deps): update ffmpeg to 6.0.1-2

### DIFF
--- a/server/bin/build-lock.json
+++ b/server/bin/build-lock.json
@@ -19,11 +19,10 @@
   "packages": [
     {
       "name": "ffmpeg",
-      "version": "6.0-4",
+      "version": "6.0.1-2",
       "sha256": {
-        "amd64": "18d98b292b891cde86c2a08e5e989c3430e51a136cdc232bc4162fef3b4f0f44",
-        "arm64": "67eb1e5a38ac695dd253d9ac290ad0e9fb709e8260449a7445e8460b7db3c516",
-        "armhf": "a29605ab0eced3511c8a6623504fab5b8bb174a486d87f94bf5522ed9a5970e6"
+        "amd64": "058d365139be586407628eeebf954b313adee411dafe9f280ee854d72c4dd7bc",
+        "arm64": "127afd0c648fa584ede6bd6a0f1586579e56d41541faf584d2d9cfbb50aa17de"
       }
     }
   ]


### PR DESCRIPTION
This PR bumps our Jellyfin build of FFmpeg to 6.0.1-2. Besides a number of bug fixes, this build natively supports hardware acceleration for Rockchip RK3588. This lets us simplify the deployment process for this backend and remove some hacky code.