### PR TITLE
chore: add mesa vulkan drivers

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -97,6 +97,7 @@ RUN apt-get update && \
         libwebpdemux2 \
         libwebpmux3 \
         mesa-va-drivers \
+        mesa-vulkan-drivers \
         tini \
         wget \
         zlib1g && \


### PR DESCRIPTION
### Description

This is needed to use libplacebo for hardware-accelerated tone-mapping, tested with nvenc.