### PR TITLE
chore(deps): update libraw

### DIFF
--- a/server/bin/build-lock.json
+++ b/server/bin/build-lock.json
@@ -7,8 +7,8 @@
     },
     {
       "name": "libraw",
-      "version": "0.21.1",
-      "revision": "cccb97647fcee56801fa68231fa8a38aa8b52ef7"
+      "version": "0.22.0-SNAPSHOT",
+      "revision": "d3cbbd0e9934898eb28e4963ee99b51928e2acaa"
     },
     {
       "name": "libvips",


### PR DESCRIPTION
### Description

There's an increasing number of issues stemming from the current release not having support for newer cameras or formats. Support has been added for these since then, but libraw has a very sporadic release cadence and waiting for the next release could mean many months. This PR uses the current state of libraw until the next release.