### PR TITLE
feat: add country boundaries file to image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -58,6 +58,7 @@ RUN ./install-ffmpeg.sh
 ADD https://download.geonames.org/export/dump/cities500.zip /usr/src/resources/cities500.zip
 ADD --chmod=444 https://download.geonames.org/export/dump/admin1CodesASCII.txt /usr/src/resources/admin1CodesASCII.txt
 ADD --chmod=444 https://download.geonames.org/export/dump/admin2Codes.txt /usr/src/resources/admin2Codes.txt
+ADD --chmod=444 https://raw.githubusercontent.com/nvkelso/natural-earth-vector/v5.1.2/geojson/ne_10m_admin_0_countries.geojson /usr/src/resources/ne_10m_admin_0_countries.geojson
 
 RUN umask 0333 && unzip /usr/src/resources/cities500.zip -d /usr/src/resources/ && \
     rm /usr/src/resources/cities500.zip && date --iso-8601=seconds | tr -d "\n" > /usr/src/resources/geodata-date.txt


### PR DESCRIPTION
Add country boundaries file to image. A [geoJSON file](https://github.com/nvkelso/natural-earth-vector/blob/ca96624a56bd078437bca8184e78163e5039ad19/geojson/ne_10m_admin_0_countries.geojson) containing boundary polygons for each country from [Natural Earth](https://www.naturalearthdata.com/). 

Will be used for geocoding images with remote locations which the current cities geocoding fails: https://github.com/immich-app/immich/pull/10950

Built and tested locally.