### PR TITLE
feat: build libheif

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,10 +5,13 @@ WORKDIR /usr/src/app
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH \
     LD_RUN_PATH=/usr/local/lib:$LD_RUN_PATH
 
-RUN apt-get update && \
+COPY bin/configure-apt.sh ./
+RUN ./configure-apt.sh && \
+    apt-get update && \
     apt-get install --no-install-recommends -yqq \
         autoconf \
         build-essential \
+        cmake \
         jq \
         perl \
         libnet-ssleay-perl \
@@ -33,23 +36,26 @@ RUN apt-get update && \
         libexpat1-dev \
         libglib2.0-dev \
         libgsf-1-dev \
-        libheif-dev \
         libjpeg62-turbo-dev \
         libjxl-dev \
         liblcms2-2 \
         liborc-0.4-dev \
         librsvg2-dev \
         libspng-dev \
-        libwebp-dev \
         meson \
         ninja-build \
         pkg-config \
         wget \
         zlib1g \
-        cpanminus
+        cpanminus && \
+    apt-get install -t unstable --no-install-recommends -yqq \
+        libwebp-dev \
+        libdav1d-dev \
+        libde265-dev
 
 COPY bin/* ./
 
+RUN ./build-libheif.sh
 RUN ./build-libraw.sh
 RUN ./build-imagemagick.sh
 RUN ./build-libvips.sh
@@ -67,8 +73,6 @@ FROM node:20.15.1-bookworm-slim@sha256:8d5c168087c841ac367468f77935aa78eff3195b4
 
 WORKDIR /build
 
-RUN sed -i -e's/ main/ main contrib non-free non-free-firmware/g' /etc/apt/sources.list.d/debian.sources
-
 COPY bin/build-lock.json bin/configure-apt.sh bin/install-ffmpeg.sh  ./
 
 RUN ./configure-apt.sh && \
@@ -82,7 +86,6 @@ RUN ./configure-apt.sh && \
         libglib2.0-0 \
         libgomp1 \
         libgsf-1-114 \
-        libheif1 \
         libjpeg62-turbo \
         libjxl0.7 \
         liblcms2-2 \
@@ -94,9 +97,6 @@ RUN ./configure-apt.sh && \
         liborc-0.4-0 \
         librsvg2-2 \
         libspng0 \
-        libwebp7 \
-        libwebpdemux2 \
-        libwebpmux3 \
         mesa-utils \
         mesa-va-drivers \
         mesa-vulkan-drivers \
@@ -107,7 +107,11 @@ RUN ./configure-apt.sh && \
     if [ $(arch) = "x86_64" ]; then \
     apt-get install -t unstable --no-install-recommends -yqq \
         intel-media-va-driver-non-free \
-        intel-opencl-icd; fi && \
+        intel-opencl-icd \
+        libwebp7 \
+        libwebpdemux2 \
+        libwebpmux3 \
+        libde265-0; fi && \
     apt-get remove -yqq jq wget ca-certificates && \
     apt-get autoremove -yqq && \
     apt-get clean && \
@@ -118,5 +122,6 @@ COPY --from=dev /usr/local/lib/ /usr/local/lib/
 COPY --from=dev /build/geodata/ /build/geodata/
 
 WORKDIR /usr/src/app
+ENV LD_LIBRARY_PATH=/usr/lib/jellyfin-ffmpeg/lib:$LD_LIBRARY_PATH
 
 RUN ldconfig /usr/local/lib

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -32,6 +32,7 @@ RUN ./configure-apt.sh && \
         libany-uri-escape-perl \
         libmojolicious-perl \
         libfile-slurper-perl \
+        libde265-dev \
         libexif-dev \
         libexpat1-dev \
         libglib2.0-dev \
@@ -49,9 +50,8 @@ RUN ./configure-apt.sh && \
         zlib1g \
         cpanminus && \
     apt-get install -t unstable --no-install-recommends -yqq \
-        libwebp-dev \
         libdav1d-dev \
-        libde265-dev
+        libwebp-dev
 
 COPY bin/* ./
 
@@ -80,6 +80,7 @@ RUN ./configure-apt.sh && \
     apt-get install --no-install-recommends -yqq \
         ca-certificates \
         jq \
+        libde265-0 \
         libexif12 \
         libexpat1 \
         libgcc-s1 \
@@ -110,8 +111,7 @@ RUN ./configure-apt.sh && \
         intel-opencl-icd \
         libwebp7 \
         libwebpdemux2 \
-        libwebpmux3 \
-        libde265-0; fi && \
+        libwebpmux3; fi && \
     apt-get remove -yqq jq wget ca-certificates && \
     apt-get autoremove -yqq && \
     apt-get clean && \

--- a/server/bin/build-libheif.sh
+++ b/server/bin/build-libheif.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+: "${LIBHEIF_REVISION:=$(jq -cr '.sources[] | select(.name == "libheif").revision' build-lock.json)}"
+
+git clone https://github.com/strukturag/libheif.git
+cd libheif
+git reset --hard $LIBHEIF_REVISION
+
+mkdir build
+cd build
+cmake --preset=release-noplugins \
+    -DWITH_DAV1D=ON \
+    -DENABLE_PARALLEL_TILE_DECODING=ON \
+    -DENABLE_LIBSHARPYUV=ON \
+    -DENABLE_LIBDE265=ON \
+    -DWITH_AOM_DECODER=OFF \
+    -DWITH_AOM_ENCODER=OFF \
+    -DWITH_X265=OFF \
+    -DWITH_EXAMPLES=OFF \
+    ..
+make install
+cd ../.. && rm -rf libheif
+ldconfig /usr/local/lib

--- a/server/bin/build-lock.json
+++ b/server/bin/build-lock.json
@@ -6,6 +6,11 @@
       "revision": "963f5fa2a3c87b362e2b6b29a31bff447b75925b"
     },
     {
+      "name": "libheif",
+      "version": "1.18.0",
+      "revision": "537d66852629e23ca778ef717343be8f657c0e79"
+    },
+    {
       "name": "libraw",
       "version": "0.22.0-SNAPSHOT",
       "revision": "d3cbbd0e9934898eb28e4963ee99b51928e2acaa"


### PR DESCRIPTION
### Description

There's currently an issue with iOS 18 images not being processed due to the libheif version on the server. This PR addresses that by building an up-to-date version of libheif that patches this. It's generally good to have more control over this dependency anyway since it's very important and changes frequently in tandem with the industry.
* Changes libwebp to be sourced from sid as it has a more recent sister dependency, libsharpyuv, that libheif can also use for improved color processing
  * This dependency is the solution to an issue I noticed with WebP video thumbnail generation, so this kills two birds with one stone
* dav1d (used for AVIF) essentially comes for free since our FFmpeg build already includes it

### How Has This Been Tested?

Tested that the server starts up without any errors from libvips (it warns if libheif couldn't be loaded) and that the sample image in [this](https://github.com/immich-app/immich/issues/10464) issue generated successfully.

![thumbnail](https://github.com/user-attachments/assets/b161eb7d-de10-46f0-a788-0c023e908f93)
