### PR TITLE
chore: add wsl path to `LD_LIBRARY_PATH`

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -121,6 +121,6 @@ COPY --from=dev /usr/local/lib/ /usr/local/lib/
 COPY --from=dev /build/geodata/ /build/geodata/
 
 WORKDIR /usr/src/app
-ENV LD_LIBRARY_PATH=/usr/lib/jellyfin-ffmpeg/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/lib/jellyfin-ffmpeg/lib:/usr/lib/wsl/lib:$LD_LIBRARY_PATH
 
 RUN ldconfig /usr/local/lib


### PR DESCRIPTION
### Description

The `LD_LIBRARY_PATH` in the base image gets overridden by the `vaapi-wsl` HWA config that also sets `LD_LIBRARY_PATH`. I think it's better to set this in the base image and remove the env from `vaapi-wsl`. This way, we can internally change it as needed without it being a breaking change.