### PR TITLE
Update libjxl-dev and libjxl to 0.9, fix jxl export by Adobe ACR decode failed

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,7 +21,6 @@ RUN ./configure-apt.sh && \
         libglib2.0-dev \
         libgsf-1-dev \
         libjpeg62-turbo-dev \
-        libjxl-dev \
         liblcms2-2 \
         liborc-0.4-dev \
         librsvg2-dev \
@@ -36,6 +35,7 @@ RUN ./configure-apt.sh && \
         libdav1d-dev \
         libwebp-dev && \
     apt-get install -t testing --no-install-recommends -yqq \
+        libjxl-dev \
         libio-compress-brotli-perl
 
 COPY bin/* ./
@@ -73,7 +73,6 @@ RUN ./configure-apt.sh && \
         libgomp1 \
         libgsf-1-114 \
         libjpeg62-turbo \
-        libjxl0.7 \
         liblcms2-2 \
         liblqr-1-0 \
         libltdl7 \
@@ -95,6 +94,8 @@ RUN ./configure-apt.sh && \
         libwebp7 \
         libwebpdemux2 \
         libwebpmux3 && \
+    apt-get install -t testing --no-install-recommends -yqq \
+        libjxl0.9 && \
     apt-get remove -yqq jq wget ca-certificates && \
     apt-get autoremove -yqq && \
     apt-get clean && \


### PR DESCRIPTION
Releated issue: [Failed to generate preview for Adobe ACR exported JXL picture. · Issue #11938 · immich-app/immich](https://github.com/immich-app/immich/issues/11938)

The depencies `libjxl-dev` and `libjxl0.7` are a little old and may cause some JXL decode failed(such as Adobe ACR export one). This pull request upgrade them to 0.9 (channel: debian testing) .

I had manually build and test several JXL files.

## images build

All images (dev and prod) build success without error.

## JXL test

There're four JXL files, half of them are Adobe ACR exported and others are transcode using libjxl offical tools.

In each two files, one is lossless, 16bit deepth and another is lessly, 8bit deepth.

Here are the file list:

![image](https://github.com/user-attachments/assets/fa85cd2c-29e5-4f72-894b-c4e0847362ef)

Upload those files and they works fine.

![image](https://github.com/user-attachments/assets/cb0c4047-cd12-456c-8e5b-48a2e12055cf)
![image](https://github.com/user-attachments/assets/cbc2fe41-6497-44b1-8338-b10d01af7f2d)

This is my first pull request, if there's and problem, please comment and I'll try fix.