### PR TITLE
chore: update to jellyfin-ffmpeg7

### DIFF
--- a/server/bin/build-lock.json
+++ b/server/bin/build-lock.json
@@ -29,10 +29,10 @@
   "packages": [
     {
       "name": "ffmpeg",
-      "version": "6.0.1-8",
+      "version": "7.0.2-3",
       "sha256": {
-        "amd64": "dab2d0b5247dc20f29ada768842c988633834bfecfe1601580f964649979b865",
-        "arm64": "5fe705505898e25c3724451c26c90b4d5b6e25a8e1e6b825a4601b4d7819a160"
+        "amd64": "803a45a951f725c7909fa9615eedea513c374c9f6b4a0a26628ea2fd3521a38b",
+        "arm64": "45a796a092e9a25408978424dc9c9c579532f6cc583671afa71f7d9b8a12565b"
       }
     }
   ]

--- a/server/bin/install-ffmpeg.sh
+++ b/server/bin/install-ffmpeg.sh
@@ -7,12 +7,12 @@ export TARGETARCH=${TARGETARCH:=$(dpkg --print-architecture)}
 FFMPEG_VERSION=${FFMPEG_VERSION:=$(echo $LOCK | jq -r '.version')}
 FFMPEG_SHA256=${FFMPEG_SHA256:=$(echo $LOCK | jq -r '.sha256[$ENV.TARGETARCH]')}
 
-echo "$FFMPEG_SHA256  jellyfin-ffmpeg6_${FFMPEG_VERSION}-bookworm_${TARGETARCH}.deb" > ffmpeg.sha256
+echo "$FFMPEG_SHA256  jellyfin-ffmpeg7_${FFMPEG_VERSION}-bookworm_${TARGETARCH}.deb" > ffmpeg.sha256
 
-wget -nv https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v${FFMPEG_VERSION}/jellyfin-ffmpeg6_${FFMPEG_VERSION}-bookworm_${TARGETARCH}.deb
+wget -nv https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v${FFMPEG_VERSION}/jellyfin-ffmpeg7_${FFMPEG_VERSION}-bookworm_${TARGETARCH}.deb
 sha256sum -c ffmpeg.sha256
-apt-get -yqq -f install ./jellyfin-ffmpeg6_${FFMPEG_VERSION}-bookworm_${TARGETARCH}.deb
-rm jellyfin-ffmpeg6_${FFMPEG_VERSION}-bookworm_${TARGETARCH}.deb
+apt-get -yqq -f install ./jellyfin-ffmpeg7_${FFMPEG_VERSION}-bookworm_${TARGETARCH}.deb
+rm jellyfin-ffmpeg7_${FFMPEG_VERSION}-bookworm_${TARGETARCH}.deb
 rm ffmpeg.sha256
 ldconfig /usr/lib/jellyfin-ffmpeg/lib
 


### PR DESCRIPTION
### Description

This should fix a few current bugs, add some new codec and filter options and make using Vulkan more viable. It may or may not have a performance difference; I haven't tested.

Tested on CPU and CUDA with every target video codec, tone-mapping enabled/disabled and hardware decoding enabled/disabled.