### PR TITLE
fix: lint and jpegli version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/server/bin/build-imagemagick.sh
+++ b/server/bin/build-imagemagick.sh
@@ -6,10 +6,10 @@ set -e
 
 git clone https://github.com/ImageMagick/ImageMagick.git
 cd ImageMagick
-git reset --hard $IMAGEMAGICK_REVISION
+git reset --hard "$IMAGEMAGICK_REVISION"
 
 ./configure --with-modules
-make -j$(nproc)
+make -j"$(nproc)"
 make install
 cd .. && rm -rf ImageMagick
 ldconfig /usr/local/lib

--- a/server/bin/build-libheif.sh
+++ b/server/bin/build-libheif.sh
@@ -6,7 +6,7 @@ set -e
 
 git clone https://github.com/strukturag/libheif.git
 cd libheif
-git reset --hard $LIBHEIF_REVISION
+git reset --hard "$LIBHEIF_REVISION"
 
 mkdir build
 cd build

--- a/server/bin/build-libjxl.sh
+++ b/server/bin/build-libjxl.sh
@@ -2,11 +2,23 @@
 
 set -e
 
+JPEGLI_LIBJPEG_LIBRARY_SOVERSION="62"
+JPEGLI_LIBJPEG_LIBRARY_VERSION="62.3.0"
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --JPEGLI_LIBJPEG_LIBRARY_SOVERSION) JPEGLI_LIBJPEG_LIBRARY_SOVERSION="$2"; shift ;;
+        --JPEGLI_LIBJPEG_LIBRARY_VERSION) JPEGLI_LIBJPEG_LIBRARY_VERSION="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
 : "${LIBJXL_REVISION:=$(jq -cr '.sources[] | select(.name == "libjxl").revision' build-lock.json)}"
 
 git clone https://github.com/libjxl/libjxl.git
 cd libjxl
-git reset --hard $LIBJXL_REVISION
+git reset --hard "$LIBJXL_REVISION"
 git submodule update --init --recursive --depth 1 --recommend-shallow
 
 mkdir build
@@ -27,8 +39,10 @@ cmake \
   -DJPEGXL_ENABLE_AVX512=ON \
   -DJPEGXL_ENABLE_AVX512_ZEN4=ON \
   -DJPEGXL_ENABLE_PLUGINS=ON \
+  -DJPEGLI_LIBJPEG_LIBRARY_SOVERSION="${JPEGLI_LIBJPEG_LIBRARY_SOVERSION}" \
+  -DJPEGLI_LIBJPEG_LIBRARY_VERSION="${JPEGLI_LIBJPEG_LIBRARY_VERSION}" \
   ..
-cmake --build . -- -j$(nproc)
+cmake --build . -- -j"$(nproc)"
 cmake --install .
 cd ../.. && rm -rf libjxl
 ldconfig /usr/local/lib

--- a/server/bin/build-libraw.sh
+++ b/server/bin/build-libraw.sh
@@ -6,11 +6,11 @@ set -e
 
 git clone https://github.com/libraw/libraw.git
 cd libraw
-git reset --hard $LIBRAW_REVISION
+git reset --hard "$LIBRAW_REVISION"
 
 autoreconf --install
 ./configure
-make -j$(nproc)
+make -j"$(nproc)"
 make install
 cd .. && rm -rf libraw
 ldconfig /usr/local/lib

--- a/server/bin/build-libvips.sh
+++ b/server/bin/build-libvips.sh
@@ -6,7 +6,7 @@ set -e
 
 git clone https://github.com/libvips/libvips.git
 cd libvips
-git reset --hard $LIBVIPS_REVISION
+git reset --hard "$LIBVIPS_REVISION"
 
 meson setup build --buildtype=release --libdir=lib -Dintrospection=disabled -Dtiff=disabled
 cd build

--- a/server/bin/install-ffmpeg.sh
+++ b/server/bin/install-ffmpeg.sh
@@ -4,15 +4,15 @@ set -e
 
 LOCK=$(jq -c '.packages[] | select(.name == "ffmpeg")' build-lock.json)
 export TARGETARCH=${TARGETARCH:=$(dpkg --print-architecture)}
-FFMPEG_VERSION=${FFMPEG_VERSION:=$(echo $LOCK | jq -r '.version')}
-FFMPEG_SHA256=${FFMPEG_SHA256:=$(echo $LOCK | jq -r '.sha256[$ENV.TARGETARCH]')}
+FFMPEG_VERSION=${FFMPEG_VERSION:=$(echo "$LOCK" | jq -r '.version')}
+FFMPEG_SHA256=${FFMPEG_SHA256:=$(echo "$LOCK" | jq -r '.sha256[$ENV.TARGETARCH]')}
 
 echo "$FFMPEG_SHA256  jellyfin-ffmpeg7_${FFMPEG_VERSION}-bookworm_${TARGETARCH}.deb" > ffmpeg.sha256
 
-wget -nv https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v${FFMPEG_VERSION}/jellyfin-ffmpeg7_${FFMPEG_VERSION}-bookworm_${TARGETARCH}.deb
+wget -nv https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v"${FFMPEG_VERSION}"/jellyfin-ffmpeg7_"${FFMPEG_VERSION}"-bookworm_"${TARGETARCH}".deb
 sha256sum -c ffmpeg.sha256
-apt-get -yqq -f install ./jellyfin-ffmpeg7_${FFMPEG_VERSION}-bookworm_${TARGETARCH}.deb
-rm jellyfin-ffmpeg7_${FFMPEG_VERSION}-bookworm_${TARGETARCH}.deb
+apt-get -yqq -f install ./jellyfin-ffmpeg7_"${FFMPEG_VERSION}"-bookworm_"${TARGETARCH}".deb
+rm jellyfin-ffmpeg7_"${FFMPEG_VERSION}"-bookworm_"${TARGETARCH}".deb
 rm ffmpeg.sha256
 ldconfig /usr/lib/jellyfin-ffmpeg/lib
 


### PR DESCRIPTION
This PR:
- fix lint issues
- add a github actions like in the immich repo to test with shellcheck that all shell files are valid
- add an option to specify the JPEGLI_LIBJPEG version with `--JPEGLI_LIBJPEG_LIBRARY_SOVERSION` and `--JPEGLI_LIBJPEG_LIBRARY_VERSION` (ubuntu and debian use different versions) https://github.com/libvips/libvips/discussions/4177