### PR TITLE
chore: remove buildkit pin

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,9 +37,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.10.0
-        with:
-          # Temp: 0.20.0 is broken. https://github.com/moby/buildkit/issues/5767
-          driver-opts: image=moby/buildkit:v0.19.0
       
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
I think this is fixed now