### PR TITLE
chore: bump libraw

### DIFF
--- a/server/bin/build-lock.json
+++ b/server/bin/build-lock.json
@@ -17,8 +17,8 @@
     },
     {
       "name": "libraw",
-      "version": "0.21.3",
-      "revision": "261c18ca0f1f9b83a53947b77751050d90d18e67"
+      "version": "0.22.0-SNAPSHOT",
+      "revision": "09bea31181b43e97959ee5452d91e5bc66365f1f"
     },
     {
       "name": "libvips",


### PR DESCRIPTION
This PR updates libraw to use the 2025-02 snapshot with wider camera and format compatibility, including for Samsung phones.

We changed from a snapshot to the September 0.21.3 release, but libraw patch releases apparently only cherry pick fixes without adding camera or format support. This PR effectively fixes many regressions in RAW support caused by not using a snapshot release.