### PR TITLE
fix(postgres): unescape `$` for health check

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -30,6 +30,6 @@ RUN if [ -n "$PGVECTORS_TAG" ]; then \
         sed -i "s/, public/, public, vectors/" /etc/postgresql/postgresql.*.conf; \
     fi
 
-HEALTHCHECK --interval=5m --start-interval=30s --start-period=5m CMD pg_isready --dbname="$${POSTGRES_DB}" --username="$${POSTGRES_USER}" || exit 1; Chksum="$$(psql --dbname="$${POSTGRES_DB}" --username="$${POSTGRES_USER}" --tuples-only --no-align --command='SELECT COALESCE(SUM(checksum_failures), 0) FROM pg_stat_database')"; echo "checksum failure count is $$Chksum"; [ "$$Chksum" = '0' ] || exit 1
+HEALTHCHECK --interval=5m --start-interval=30s --start-period=5m CMD pg_isready --dbname="${POSTGRES_DB}" --username="${POSTGRES_USER}" || exit 1; Chksum="$(psql --dbname="${POSTGRES_DB}" --username="${POSTGRES_USER}" --tuples-only --no-align --command='SELECT COALESCE(SUM(checksum_failures), 0) FROM pg_stat_database')"; echo "checksum failure count is $Chksum"; [ "$Chksum" = '0' ] || exit 1
 
 CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.ssd.conf"]


### PR DESCRIPTION
It is not `docker-compose.yml`, so you don't need to escape the `$`.