### PR TITLE
feat: env for postgres storage type

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -31,5 +31,5 @@ RUN if [ -n "$PGVECTORS_TAG" ]; then \
     fi
 
 HEALTHCHECK --interval=5m --start-interval=30s --start-period=5m CMD pg_isready --dbname="${POSTGRES_DB}" --username="${POSTGRES_USER}" || exit 1; Chksum="$(psql --dbname="${POSTGRES_DB}" --username="${POSTGRES_USER}" --tuples-only --no-align --command='SELECT COALESCE(SUM(checksum_failures), 0) FROM pg_stat_database')"; echo "checksum failure count is $Chksum"; [ "$Chksum" = '0' ] || exit 1
-
-CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.ssd.conf"]
+ENV DB_STORAGE_TYPE=ssd
+CMD ["postgres", "-c", "config_file=/etc/postgresql/postgresql.$DB_STORAGE_TYPE.conf"]


### PR DESCRIPTION
This allows users to tune the database to the storage medium without needing to override the command: simply setting `DB_STORAGE_TYPE=hdd` is enough. The default value is `ssd` as before.

We can document this environmental variable in the main repo.