### PR TITLE
remove vchord latest tag

### DIFF
--- a/.github/workflows/build-postgres.yml
+++ b/.github/workflows/build-postgres.yml
@@ -134,7 +134,6 @@ jobs:
             type=raw,value=${{ matrix.pg }}-vectorchord${{ matrix.vectorchord }}-pgvectors${{ matrix.pgvectors }},enable=${{matrix.pgvectors != '' && matrix.pgvector == fromJson(steps.latest-pgvector.outputs.result) }}
             type=raw,value=${{ matrix.pg }}-vectorchord${{ matrix.vectorchord }}-pgvector${{ matrix.pgvector }},enable=${{ matrix.pgvectors == '' }}
             type=raw,value=${{ matrix.pg }}-vectorchord${{ matrix.vectorchord }},enable=${{ matrix.pgvectors == '' && matrix.pgvector == fromJson(steps.latest-pgvector.outputs.result) }}
-            type=raw,value=${{ matrix.pg }},enable=${{ matrix.pgvectors == '' && matrix.vectorchord == fromJson(steps.latest-vchord.outputs.result) && matrix.pgvector == fromJson(steps.latest-pgvector.outputs.result) }}
 
       - name: Build and push image
         uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0


### PR DESCRIPTION
Since we're changing to constrain minor releases of VectorChord, these tags will cause issues for users as they'll update to releases rejected by the server.