### PR TITLE
fix: allow any user to write to /etc/postgresql for rootless setups

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*
 
+RUN chmod 1777 /etc/postgresql
+
 COPY postgresql.hdd.conf postgresql.ssd.conf /etc/postgresql/
 COPY immich-docker-entrypoint.sh /usr/local/bin/
 

--- a/postgres/docker-compose.yml
+++ b/postgres/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    container_name: base_images_postgres
+    user: 1001:1001
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      args:
+        PG_MAJOR: 14
+        VECTORCHORD_TAG: 0.3.0
+        PGVECTOR_TAG: 0.8.0
+        PGVECTORS_TAG: 0.3.0
+    environment:
+      POSTGRES_PASSWORD: "password"
+      POSTGRES_USERNAME: "username"
+      POSTGRES_DB: "database_name"
+      POSTGRES_INITDB_ARGS: '--data-checksums'
+    volumes:
+      - ./data:/var/lib/postgresql/data
+    restart: always


### PR DESCRIPTION
This change will set /etc/postgresql folder to permissions 1777 which will allow any user to write a file to the /etc/postgresql folder which will allow our config file to be created. Once it is created there, no other user will be able to modify or delete that file in any way due to setting the sticky bit in the permissions and the file itself being created with 644 permissions.

This is the directory layout and permissions after this change for /etc/postgres when running with `user: 1001:1001`
![image](https://github.com/user-attachments/assets/19b3e461-1837-454c-80f1-cc5c72222d32)


Fixes immich-app/immich#18431