### PR TITLE
Fix pgvecto.rs 0.3.0 installation on Postgres 17

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     apt-get install -y wget && \
     wget -nv -O /tmp/vchord.deb https://github.com/tensorchord/VectorChord/releases/download/$VECTORCHORD_TAG/postgresql-${PG_MAJOR%.*}-vchord_${VECTORCHORD_TAG#"v"}-1_${TARGETARCH}.deb && \
     if [ -n "$PGVECTORS_TAG" ]; then \
-        wget -nv -O /tmp/pgvectors.deb https://github.com/tensorchord/pgvecto.rs/releases/download/v$PGVECTORS_TAG/vectors-pg${PG_MAJOR%.*}_${PGVECTORS_TAG#"v"}_${TARGETARCH}$(if [ "$PGVECTORS_TAG" = '0.3.0']; then echo "_vectors"; fi).deb; \
+        wget -nv -O /tmp/pgvectors.deb https://github.com/tensorchord/pgvecto.rs/releases/download/v$PGVECTORS_TAG/vectors-pg${PG_MAJOR%.*}_${PGVECTORS_TAG#"v"}_${TARGETARCH}$(if [ "$PGVECTORS_TAG" = '0.3.0' ]; then echo "_vectors"; fi).deb; \
         apt-get install -y /tmp/pgvectors.deb; \
         rm -f /tmp/pgvectors.deb; \
     fi && \


### PR DESCRIPTION
Fix a missing whitespace. It prevented adding _vectors suffix while installing pgvectors 0.3.0.

The issue raised by [@urbaman](https://github.com/urbaman) at https://github.com/immich-app/immich/issues/18431#issuecomment-2904067477.

Installation fails only on pg17 because
- For pg17 only deb with _vectors suffix was released at https://github.com/tensorchord/pgvecto.rs/releases/tag/v0.3.0:
    - vectors-pg17_0.3.0_amd64_vectors.deb
- For earlier PG versions there are two debs - with and without _vectors suffix:
    - vectors-pg16_0.3.0_amd64_vectors.deb
    - vectors-pg16_0.3.0_amd64.deb

Why didn't the docker image build job fail? It seems `if` eats an error:
```
if [ "$PGVECTORS_TAG" = '0.3.0']; then echo "_vectors"; fi ; echo $?

bash: [: missing `]'
0

# compare: error propagates without `if`
[ "$PGVECTORS_TAG" = '0.3.0'] && echo "_vectors" ; echo $?

bash: [: missing `]'
2
```