### PR TITLE
fix: preserve postgres config permissions to ensure 644

### DIFF
--- a/postgres/immich-docker-entrypoint.sh
+++ b/postgres/immich-docker-entrypoint.sh
@@ -5,7 +5,7 @@
 case "${DB_STORAGE_TYPE^^}" in
   SSD|HDD)
     echo "Using ${DB_STORAGE_TYPE^^} storage"
-    cp -n "/etc/postgresql/postgresql.${DB_STORAGE_TYPE,,}.conf" /etc/postgresql/postgresql.conf
+    cp -n --preserve=mode "/etc/postgresql/postgresql.${DB_STORAGE_TYPE,,}.conf" /etc/postgresql/postgresql.conf
     sed -i "s@##PGDATA@$PGDATA@" /etc/postgresql/postgresql.conf; \
     ;;
   *)


### PR DESCRIPTION
ACLs on the host filesystem can cause a standard copy to not create the new file as 644 and then the postgres user cannot read the file. overlay2 takes the ACL from the base image on the filesystem when merging them with overlayfs