### PR TITLE
chore: bump vchord to 0.4.2

### DIFF
--- a/postgres/versions.yaml
+++ b/postgres/versions.yaml
@@ -6,7 +6,7 @@ pg:
 vectorchord:
   # renovate: datasource=github-releases depName=tensorchord/VectorChord
   - "0.3.0"
-  - "0.4.1"
+  - "0.4.2"
 pgvector:
   - "0.8.0"
 pgvectors:


### PR DESCRIPTION
Since we haven't made an immich release that supports 0.4.1 yet, this PR replaces the 0.4.1 entry.