### PR TITLE
chore: Update libvips

### DIFF
--- a/server/sources/libvips.json
+++ b/server/sources/libvips.json
@@ -1,5 +1,5 @@
 {
     "name": "libvips",
-    "version": "8.16.1",
-    "revision": "82c7c05cb02a52750251bb4cc69d67f40568cf98"
+    "version": "8.17.1",
+    "revision": "8fa37a64547e392d3808eed8d72adab7e02b3d00"
 }


### PR DESCRIPTION
Here I ran into an issue trying to test the new image:
```

immich_server            | /usr/src/app/node_modules/sharp/lib/sharp.js:121
immich_server            |   throw new Error(help.join('\n'));
immich_server            |   ^
immich_server            |
immich_server            | Error: Could not load the "sharp" module using the linux-arm64 runtime
immich_server            | ERR_DLOPEN_FAILED: libvips-cpp.so.8.16.1: cannot open shared object file: No such file or directory
immich_server            | Possible solutions:
immich_server            | - Ensure optional dependencies can be installed:
immich_server            |     npm install --include=optional sharp
immich_server            | - Ensure your package manager supports multi-platform installation:
immich_server            |     See https://sharp.pixelplumbing.com/install#cross-platform
immich_server            | - Add platform-specific dependencies:
immich_server            |     npm install --os=linux --cpu=arm64 sharp
immich_server            | - Consult the installation documentation:
immich_server            |     See https://sharp.pixelplumbing.com/install
```
Not sure what went wrong during building the image, maybe some caching problems.
Here it might also make sense to wait for a tag for v8.17.1.