### PR TITLE
chore: update libheif to fix 100% CPU usage due to corrupted HEIC images

### DIFF
--- a/server/sources/libheif.json
+++ b/server/sources/libheif.json
@@ -1,5 +1,5 @@
 {
     "name": "libheif",
-    "version": "1.19.8",
-    "revision": "5e9deb19fe6b3768af0bb8e9e5e8438b15171bf3"
+    "version": "1.20.2",
+    "revision": "35dad50a9145332a7bfdf1ff6aef6801fb613d68"
 }


### PR DESCRIPTION
libheif v1.19.8 does not properly detect corrupted HEIC and spins in an infinite loop with full 1 core 100% CPU usage (per thread / thumbnail generation job).
Seems fixed in v1.20, see the main issue thread.

- main issue https://github.com/immich-app/immich/issues/14349
- duplicate https://github.com/immich-app/immich/issues/20516
- libheif issue: https://github.com/strukturag/libheif/pull/1492

Another/unrelated noticeable change in v1.20:
> You can specify a security limit for the maximum total memory libheif may use for decoding. This is easier to handle than specifying limits on the maximum image size or single memory allocations.