### PR TITLE
fix(server): memory leak in allocator

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -161,9 +161,9 @@ WORKDIR /build
 
 COPY configure-apt.sh packages/ffmpeg.json packages/ffmpeg.sh ./
 
-RUN apt-get update && \
+RUN ./configure-apt.sh && \
+    apt-get update && \
     apt-get install curl ca-certificates --no-install-recommends -yqq && \
-    ./configure-apt.sh && \
     mkdir -p /usr/share/postgresql-common/pgdg
 
 ADD --chmod=644 https://www.postgresql.org/media/keys/ACCC4CF8.asc /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
@@ -182,7 +182,6 @@ RUN echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.as
         liblcms2-2 \
         liblqr-1-0 \
         libltdl7 \
-        libmimalloc3 \
         libopenexr-3-1-30 \
         libopenjp2-7 \
         librsvg2-2 \
@@ -213,6 +212,7 @@ RUN echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.as
         dpkg -i *.deb && \
         apt-get install --no-install-recommends -yqq intel-media-va-driver-non-free; \
     fi && \
+    apt-get install -t testing --no-install-recommends -yqq libmimalloc3 && \
     apt-get remove -yqq jq wget ca-certificates && \
     apt-get autoremove -yqq && \
     apt-get clean && \

--- a/server/configure-apt.sh
+++ b/server/configure-apt.sh
@@ -4,20 +4,19 @@ set -e
 
 sed -i -e's/ main/ main contrib non-free non-free-firmware/g' /etc/apt/sources.list.d/debian.sources
 
-# Note: the following lines are commented out because mixing trixie with unstable/testing causes package
-# resolution conflicts due to the time64 migration. Trixie rebuilt all packages with a 64 bit time_t, but
-# they left the 32 bit time version in place. The 64 bit time version has t64 sufix in the package name.
+# Note: does not add `sid` since mixing it with trixie can cause package resolution conflicts
+# due to the time64 migration. Trixie rebuilt all packages with a 64 bit time_t, but not all
+# packages in unstable have migrated yet. The 64 bit time version has t64 suffix in the package name.
 # More info: https://lwn.net/Articles/938149/ https://wiki.debian.org/ReleaseGoals/64bit-time
-#
-# sed -i -e"s/ ${DEBIAN_RELEASE}-updates/ ${DEBIAN_RELEASE}-updates testing sid/g" /etc/apt/sources.list.d/debian.sources
-#
+sed -i -e"s/ ${DEBIAN_RELEASE}-updates/ ${DEBIAN_RELEASE}-updates testing/g" /etc/apt/sources.list.d/debian.sources
+
 # # default priority is 500, so we set unstable to 450 to prefer stable packages
-# cat > /etc/apt/preferences.d/preferences << EOL
-# Package: *
-# Pin: release a=unstable
-# Pin-Priority: 450
-#
-# Package: *
-# Pin: release a=testing
-# Pin-Priority: 450
-# EOL
+cat > /etc/apt/preferences.d/preferences << EOL
+Package: *
+Pin: release a=unstable
+Pin-Priority: 450
+
+Package: *
+Pin: release a=testing
+Pin-Priority: 450
+EOL


### PR DESCRIPTION
Trixie uses an old alpha version of libmimalloc that leaks memory. This PR changes the build to install the much newer 3.15 build.

Have confirmed that this build has much more normal memory usage during thumbnail generation, significantly lower than either with the alpha version or with `LD_PRELOAD` commented out.