### PR TITLE
fix(postgres): add pre-flight checks for disk space and filesystem

### DIFF
--- a/postgres/immich-docker-entrypoint.sh
+++ b/postgres/immich-docker-entrypoint.sh
@@ -2,6 +2,33 @@
 
 set -eo pipefail
 
+DATA_DIR="${PGDATA:-/var/lib/postgresql/data}"
+
+if [ -d "$DATA_DIR" ]; then
+  # 1. Disk Space Guard (Prevent crash loops on full disks)
+  available_space=$(df -P "$DATA_DIR" | awk 'NR==2 {print $4}')
+  if [ "$available_space" -lt 102400 ]; then
+    echo "*****************************************************"
+    echo "CRITICAL ERROR: Disk Space Exhaustion Detected"
+    echo "Available space: $((available_space / 1024)) MB"
+    echo "PostgreSQL requires at least 100MB to safely manage lock files and WAL."
+    echo "Startup aborted to prevent crash loop and corruption."
+    echo "*****************************************************"
+    exit 1
+  fi
+
+  # 2. Filesystem Permission Warning (Detect non-POSIX mounts)
+  fs_type=$(df -T "$DATA_DIR" | awk 'NR==2 {print $2}')
+  if [[ "$fs_type" == "fuseblk" || "$fs_type" == "exfat" || "$fs_type" == "vfat" ]]; then
+    echo "-----------------------------------------------------"
+    echo "WARNING: Non-POSIX Filesystem Detected ($fs_type)"
+    echo "PostgreSQL requires strict 0700 permissions on its data directory."
+    echo "If this container fails to start with 'Permission denied',"
+    echo "ensure you mounted the volume with 'uid=999,gid=999,fmask=0077,dmask=0077'."
+    echo "-----------------------------------------------------"
+  fi
+fi
+
 : "${DB_STORAGE_TYPE:=SSD}"
 
 case "${DB_STORAGE_TYPE^^}" in


### PR DESCRIPTION
### Summary
Added pre-flight safety checks to the Postgres entrypoint script (`postgres/immich-docker-entrypoint.sh`). These checks run before the database process starts to prevent common crash loops observed in self-hosted environments (particularly on Raspberry Pi and external USB storage).

### Changes
1.  **Disk Space Guard:** The script now checks if available disk space is below 100MB.
    * If space is critical, it aborts startup with `exit 1`.
    * **Why:** This prevents Postgres from failing to create `postmaster.pid` mid-startup, which typically triggers an infinite Docker Restart -> Crash loop that fills logs and freezes the host system.
2.  **Filesystem Warning:** The script detects if the data directory is on a non-POSIX filesystem (checking for `fuseblk`, `exfat`, `vfat`).
    * It prints a clear warning advising the user to set `fmask=0077,dmask=0077`.
    * **Why:** Users often encounter "Permission Denied" errors on external drives without knowing the specific mount flags required to fix it.

### Testing
* Validated script syntax using `bash -n`.
* Built the Docker image locally successfully:
    `docker build . --build-arg="PG_MAJOR=16" --build-arg="PGVECTOR_TAG=0.8.0" ...`

### Motivation
* Addresses common support issues where users mount exFAT drives or run out of SD card space, leading to database corruption or hard-to-diagnose boot loops.