### PR TITLE
feat: update image processing libraries and intel compute drivers

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -210,11 +210,11 @@ RUN echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.as
   wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17537.24/intel-igc-opencl_1.0.17537.24_amd64.deb && \
   wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.36/intel-opencl-icd-legacy1_24.35.30872.36_amd64.deb && \
   # New driver
-  wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.28.4/intel-igc-core-2_2.28.4+20760_amd64.deb && \
-  wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.28.4/intel-igc-opencl-2_2.28.4+20760_amd64.deb && \
-  wget https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/intel-opencl-icd_26.05.37020.3-0_amd64.deb &&  \
+  wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.32.7/intel-igc-core-2_2.32.7+21184_amd64.deb && \
+  wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.32.7/intel-igc-opencl-2_2.32.7+21184_amd64.deb && \
+  wget https://github.com/intel/compute-runtime/releases/download/26.14.37833.4/intel-opencl-icd_26.14.37833.4-0_amd64.deb &&  \
   # Shared libigdgmm1
-  wget -nv https://github.com/intel/compute-runtime/releases/download/26.05.37020.3/libigdgmm12_22.9.0_amd64.deb && \
+  wget -nv https://github.com/intel/compute-runtime/releases/download/26.14.37833.4/libigdgmm12_22.9.0_amd64.deb && \
   dpkg -i *.deb; \
   fi && \
   apt-get install -t testing --no-install-recommends -yqq libmimalloc3 && \

--- a/server/packages/ffmpeg.json
+++ b/server/packages/ffmpeg.json
@@ -1,8 +1,8 @@
 {
     "name": "ffmpeg",
-    "version": "7.1.3-3",
+    "version": "7.1.3-5",
     "sha256": {
-        "amd64": "adf59c48bef94251a3f16d957fc5f27f1b5f1bb6ac7819d18c629d30fd302579",
-        "arm64": "7bf5b8e210d507ed0eca2a3cc3774ddf269a0f375c8120b7d025962401df50d5"
+        "amd64": "2e62cbeb2f0d3ee45b034d32a3e48cf755b571f030ca6f34479005ad18de399f",
+        "arm64": "2fe91742a832e7ca25c38b4f6302a24e89a305dc833df9a630bb17b435b37b00"
     }
 }

--- a/server/sources/imagemagick.json
+++ b/server/sources/imagemagick.json
@@ -1,6 +1,6 @@
 {
     "name": "imagemagick",
     "repository": "ImageMagick/ImageMagick",
-    "version": "7.1.2-2",
-    "revision": "8289a3388a085ad5ae81aa6812f21554bdfd54f2"
+    "version": "7.1.2-21",
+    "revision": "c86de049cefb8dd739e16f0e2fdc1ef8d2006d59"
 }

--- a/server/sources/libheif.json
+++ b/server/sources/libheif.json
@@ -1,6 +1,6 @@
 {
     "name": "libheif",
     "repository": "strukturag/libheif",
-    "version": "1.20.2",
-    "revision": "35dad50a9145332a7bfdf1ff6aef6801fb613d68"
+    "version": "1.21.2",
+    "revision": "62f1b8c76ed4d8305071fdacbe74ef9717bacac5"
 }

--- a/server/sources/libjxl.json
+++ b/server/sources/libjxl.json
@@ -1,6 +1,6 @@
 {
     "name": "libjxl",
     "repository": "libjxl/libjxl",
-    "version": "0.11.1",
-    "revision": "794a5dcf0d54f9f0b20d288a12e87afb91d20dfc"
+    "version": "0.11.2",
+    "revision": "332feb17d17311c748445f7ee75c4fb55cc38530"
 }

--- a/server/sources/libraw.json
+++ b/server/sources/libraw.json
@@ -1,6 +1,6 @@
 {
     "name": "libraw",
     "repository": "LibRaw/LibRaw",
-    "version": "0.22.0",
-    "revision": "0b56545a4f828743f28a4345cdfdd4c49f9f9a2a"
+    "version": "0.22.1",
+    "revision": "b860248a89d9082b8e0a1e202e516f46af9adb29"
 }

--- a/server/sources/libvips.json
+++ b/server/sources/libvips.json
@@ -1,6 +1,6 @@
 {
   "name": "libvips",
   "repository": "libvips/libvips",
-  "version": "8.17.3",
-  "revision": "0c9151a4f416d2f8ae20a755db218f6637050eec"
+  "version": "8.18.2",
+  "revision": "17ad2f62dda7e39985955da189183e594683d45e"
 }


### PR DESCRIPTION
Intel: Bug fixes, better Panther Lake support, Production Wild Lake support (the market will soon be flooded with them as successors to the N100/N300 mini PCs), and Crescent Island support continues to evolve and recently moved to an "Early support" state.

Everything else: security and bug fixes.