### PR TITLE
feat: add jellyfin-ffmpeg to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,22 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>immich-app/.github:renovate-config"],
   "schedule": "on tuesday",
+  "customDatasources": {
+    "jellyfin-ffmpeg-trixie-amd64": {
+      "defaultRegistryUrlTemplate": "https://api.github.com/repos/jellyfin/jellyfin-ffmpeg/releases",
+      "format": "json",
+      "transformTemplates": [
+        "{ \"releases\": $map($[prerelease = false], function($r) { { \"version\": $replace($r.tag_name, /^v/, \"\"), \"releaseTimestamp\": $r.published_at, \"digest\": $map($filter($r.assets, function($a) { $contains($a.name, \"-trixie_amd64.deb\") and $type($a.digest) = \"string\" }), function($a) { $substringAfter($a.digest, \"sha256:\") })[0] } }) }"
+      ]
+    },
+    "jellyfin-ffmpeg-trixie-arm64": {
+      "defaultRegistryUrlTemplate": "https://api.github.com/repos/jellyfin/jellyfin-ffmpeg/releases",
+      "format": "json",
+      "transformTemplates": [
+        "{ \"releases\": $map($[prerelease = false], function($r) { { \"version\": $replace($r.tag_name, /^v/, \"\"), \"releaseTimestamp\": $r.published_at, \"digest\": $map($filter($r.assets, function($a) { $contains($a.name, \"-trixie_arm64.deb\") and $type($a.digest) = \"string\" }), function($a) { $substringAfter($a.digest, \"sha256:\") })[0] } }) }"
+      ]
+    }
+  },
   "customManagers": [
     {
       "customType": "jsonata",
@@ -13,6 +29,24 @@
       ],
       "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "jsonata",
+      "description": "Update pinned ffmpeg packages from GitHub releases",
+      "fileFormat": "json",
+      "managerFilePatterns": ["server/packages/ffmpeg.json"],
+      "matchStrings": [
+        "{ \"depName\": repository & \":amd64\", \"packageName\": repository, \"currentValue\": version, \"currentDigest\": sha256.amd64, \"datasource\": \"custom.jellyfin-ffmpeg-trixie-amd64\" }",
+        "{ \"depName\": repository & \":arm64\", \"packageName\": repository, \"currentValue\": version, \"currentDigest\": sha256.arm64, \"datasource\": \"custom.jellyfin-ffmpeg-trixie-arm64\" }"
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["jellyfin/jellyfin-ffmpeg:amd64", "jellyfin/jellyfin-ffmpeg:arm64"],
+      "groupName": "jellyfin-ffmpeg",
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<prerelease>\\d+)$",
+      "ignoreUnstable": false
     }
   ]
 }

--- a/server/packages/ffmpeg.json
+++ b/server/packages/ffmpeg.json
@@ -1,5 +1,6 @@
 {
     "name": "ffmpeg",
+    "repository": "jellyfin/jellyfin-ffmpeg",
     "version": "7.1.3-3",
     "sha256": {
         "amd64": "adf59c48bef94251a3f16d957fc5f27f1b5f1bb6ac7819d18c629d30fd302579",


### PR DESCRIPTION
## Summary

- Adds a custom JSONata datasource for `jellyfin/jellyfin-ffmpeg` GitHub releases, extracting per-arch `.deb` digests (`trixie_amd64` / `trixie_arm64`)
- Adds a custom manager for `server/packages/ffmpeg.json` to track version and per-arch SHA256 digests
- Adds a package rule grouping both arch variants and using regex versioning to preserve the `MAJOR.MINOR.PATCH-BUILD` format
- Adds `repository` field to `server/packages/ffmpeg.json` so the manager can resolve the dep name and datasource