### PR TITLE
feat(server): add GeoNames countryInfo.txt to geodata

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -79,6 +79,7 @@ FROM base AS geodata
 ADD https://download.geonames.org/export/dump/cities500.zip /build/geodata/cities500.zip
 ADD --chmod=444 https://download.geonames.org/export/dump/admin1CodesASCII.txt /build/geodata/admin1CodesASCII.txt
 ADD --chmod=444 https://download.geonames.org/export/dump/admin2Codes.txt /build/geodata/admin2Codes.txt
+ADD --chmod=444 https://download.geonames.org/export/dump/countryInfo.txt /build/geodata/countryInfo.txt
 ADD --chmod=444 https://raw.githubusercontent.com/nvkelso/natural-earth-vector/v5.1.2/geojson/ne_10m_admin_0_countries.geojson /build/geodata/ne_10m_admin_0_countries.geojson
 
 RUN umask 0333 && unzip /build/geodata/cities500.zip -d /build/geodata/ && \


### PR DESCRIPTION
Adds the GeoNames country-name file to the geodata bundle so the server can resolve country names from the same source as city and state (see immich-app/immich#30199).