### PR TITLE
fix(server): don't expose jellyfin-ffmpeg's libraries to every process

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -140,7 +140,10 @@ COPY --from=libvips /usr/local/bin/vips* /usr/local/bin/
 COPY --from=libvips /usr/local/include/vips/ /usr/local/include/vips/
 COPY --from=geodata /build/geodata /build/geodata
 
-ENV LD_LIBRARY_PATH=/usr/lib/jellyfin-ffmpeg/lib:/usr/lib/wsl/lib:$LD_LIBRARY_PATH
+# jellyfin-ffmpeg's libraries are deliberately NOT on LD_LIBRARY_PATH: its binaries
+# find them through the RUNPATH they carry, and exposing the directory to every
+# process makes its bundled libxml2.so.16 shadow the system libxml2 for librsvg.
+ENV LD_LIBRARY_PATH=/usr/lib/wsl/lib:$LD_LIBRARY_PATH
 
 RUN ldconfig /usr/local/lib
 
@@ -246,6 +249,9 @@ COPY --from=dev /build/ /build/
 
 WORKDIR /usr/src/app
 
-ENV LD_LIBRARY_PATH=/usr/lib/jellyfin-ffmpeg/lib:/usr/lib/wsl/lib
+# See the note in the dev stage: adding /usr/lib/jellyfin-ffmpeg/lib here makes
+# librsvg bind against jellyfin's libxml2 2.16 instead of the system 2.9.14 it was
+# built for, which segfaults libvips whenever it renders an SVG.
+ENV LD_LIBRARY_PATH=/usr/lib/wsl/lib
 
 RUN ldconfig /usr/local/lib


### PR DESCRIPTION
/usr/lib/jellyfin-ffmpeg/lib was on LD_LIBRARY_PATH in both the dev and prod stages. jellyfin-ffmpeg bundles its own libxml2 (libxml2.so.16, 2.16) and a libfontconfig that links it, where Debian's libfontconfig uses expat instead. With the directory on the loader path both libxml2 builds land in the global symbol scope, and librsvg - built against the system libxml2.so.2 (2.9.14) - binds its XML calls to 2.16. A SAX parser context then ends up built by one libxml2 and initialised by the other, and libvips segfaults whenever it renders an SVG. The immich api worker dies on SIGSEGV with no log line at all.

The directory does not need to be there. jellyfin-ffmpeg's binaries carry it as RUNPATH, and its libraries are not in the ld cache either, since the later `ldconfig /usr/local/lib` rebuilds the cache without them. With the entry removed, ldd on librsvg resolves libxml2 from /lib with no jellyfin references, ffmpeg and ffprobe still run with no unresolved dependencies, report identical hwaccels and the same 227 encoders, 542 decoders and 558 filters, and a libx264 transcode still succeeds.

/usr/lib/wsl/lib is kept, since ffmpeg dlopens the WSL GPU libraries from there.

Refs immich-app/immich#26605